### PR TITLE
Improve sync reliability, make first-pass downloader workflow-native, and fix page-0 feed coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python caches/env
+__pycache__/
+*.pyc
+.venv/
+
+# Local runtime artifacts
+out/
+run.log
+run.pid
+
+# Local secrets
+token.txt

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repo supports both one-shot bulk download and a reliable sync workflow that
 - **Smart Cache Sync:** Reuse API cache for speed while pulling new head-page songs.
 - **Liked Filename Prefixing:** Songs with `is_liked=true` are saved with `(Liked) ` prefix.
 - **Duplicate Handling:** Saves duplicate titles as versioned files (for example, `My Song v2.mp3`).
-- **Metadata Embedding:** Legacy downloader can embed title/artist/cover art.
-- **Proxy Support:** Legacy downloader supports HTTP/S proxies.
+- **Metadata Embedding:** First-pass downloader can embed title/artist/cover art.
+- **Proxy Support:** First-pass downloader supports HTTP/S proxies.
 
 https://imgur.com/a/Ox9goh7
 
@@ -54,7 +54,17 @@ https://i.imgur.com/PQtOIM5.jpeg
 
 **Important:** Treat your token like a password. Do not share it.
 
-### Step 2: Run the Recommended Sync Workflow
+### Step 2: First Download Attempt (Bulk)
+
+Run the first-pass downloader:
+
+```bash
+python3 Suno_downloader.py --with-thumbnail
+```
+
+This attempts to pull all currently-missing files directly from the live API feed into `out/`.
+
+### Step 3: Verify and Fill Any Gaps
 
 Run these three commands in order:
 
@@ -66,9 +76,10 @@ python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
 
 This is the expected operational workflow:
 
-1. Build/update API view and missing report.
-2. Download all currently identified missing files.
-3. Verify clean status.
+1. Run first-pass bulk downloader (`Suno_downloader.py`).
+2. Build/update API view and missing report.
+3. Download all currently identified missing files.
+4. Verify clean status.
 
 Expected clean result in `out/progress_summary.json`:
 
@@ -76,7 +87,10 @@ Expected clean result in `out/progress_summary.json`:
 - `missing_titles: 0`
 - `extra_titles: 0`
 
-### Important Targeted Update Behavior
+### Important First-Pass + Targeted Behavior
+
+- `Suno_downloader.py` now defaults to `out/` and token-file loading (`token.txt`), so it fits as workflow Step 1.
+- It avoids duplicate-heavy reruns by treating existing per-title file counts as already present and downloading only the deficit.
 
 - `targeted_update.py --once` runs in drain mode and continues until missing files are cleared (or no eligible clips remain).
 - `--max-downloads` defaults to `0`, which means unlimited per cycle (download all currently identified missing files each cycle).
@@ -95,14 +109,14 @@ Terminal B:
 python3 targeted_update.py --poll-interval 5 --stop-when-clean --max-retries 8 --download-sleep 0.05
 ```
 
-## Basic Legacy Downloader Usage
+## Direct Downloader Usage
 
 **Basic Usage:**
 ```bash
-python3 Suno_downloader.py --token "your_token_here"
+python3 Suno_downloader.py
 ```
 
-**With Thumbnail + Custom Directory:**
+**With Custom Token + Output Directory:**
 ```bash
 python3 Suno_downloader.py --token "your_token_here" --directory "My Suno Music" --with-thumbnail
 ```
@@ -128,10 +142,14 @@ python3 Suno_downloader.py --token "your_token_here" --directory "My Suno Music"
 
 ### `Suno_downloader.py`
 
-- `--token` **(Required)**
+- `--token` (optional; overrides token file)
+- `--token-file` (default: `token.txt`)
 - `--directory`
 - `--with-thumbnail`
 - `--proxy`
+- `--max-retries`
+- `--fail-on-partial`
+- `--fail-on-download-errors`
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -1,92 +1,191 @@
-# Suno Bulk Downloader
+# Suno DownloadEverything
 
-A simple command-line Python script to bulk download all of your private songs from [Suno AI](https://suno.com/).
+Reliable tools to mirror your Suno library locally, keep it synced as new songs appear, and recover missing files.
 
-This tool iterates through your library pages, downloads each song, and can optionally embed the cover art directly into the MP3 file's metadata.
+## What this repo contains
 
+- `progress_check.py`
+  - Fetches your feed (with cache and retries), compares API vs local MP3s, and writes missing/extra reports.
+- `targeted_update.py`
+  - Downloads only files currently identified as missing from cached API pages.
+  - Designed to run while `progress_check.py` is updating cache.
+- `Suno_downloader.py`
+  - Legacy full-library downloader with optional cover-art embedding.
 
-## Features
+## Filename rules
 
-- **Bulk Download:** Downloads all songs from your private library.
-- **Metadata Embedding:** Automatically embeds the title, artist, and cover art (thumbnail) into the MP3 file.
-- **File Sanitization:** Cleans up song titles to create valid filenames for any operating system.
-- **Duplicate Handling:** If a file with the same name already exists, it saves the new file with a version suffix (e.g., `My Song v2.mp3`) to avoid overwriting.
-- **Proxy Support:** Allows routing traffic through an HTTP/S proxy.
-- **User-Friendly Output:** Uses colored console output for clear and readable progress updates.
+All scripts now use the same filename convention:
 
-
-https://imgur.com/a/Ox9goh7
-
+- Normal titled song: `Song Name.mp3`
+- Duplicate title: `Song Name v2.mp3`, `Song Name v3.mp3`, etc.
+- Untitled song: `Untitled YYYY-MM-DD <clipid8>.mp3`
+- Liked song (`is_liked=true`): prefixed with `(Liked) `
+  - Example: `(Liked) Song Name.mp3`
+  - Example: `(Liked) Untitled 2026-02-07 ab12cd34.mp3`
 
 ## Requirements
 
-- [Python 3.6+](https://www.python.org/downloads/)
-- `pip` (Python's package installer, usually comes with Python)
+- Python 3.8+
+- `pip`
+- A valid Suno auth token
 
-## Installation
+Install dependencies:
 
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/your-username/your-repo-name.git
-    cd your-repo-name
-    ```
-    *(Alternatively, you can download the repository as a ZIP file and extract it.)*
-
-2.  **Install the required Python packages:**
-    ```bash
-    pip install -r requirements.txt
-    ```
-
-## How to Use
-
-The script requires a **Suno Authorization Token** to access your private library. Here’s how to find it:
-
-### Step 1: Find Your Authorization Token
-
-1.  Open your web browser and go to [suno.com](https://suno.com/) and log in.
-2.  Open your browser's **Developer Tools**. You can usually do this by pressing `F12` or `Ctrl+Shift+I` (Windows/Linux) or `Cmd+Option+I` (Mac).
-3.  Go to the **Network** tab in the Developer Tools.
-4.  In the filter box, type `feed` to easily find the right request.
-5.  Refresh the Suno page or click around your library. You should see a new request appear in the list.
-6.  Click on that request (it might be named something like `v2?hide_disliked=...`).
-7.  In the new panel that appears, go to the **Headers** tab.
-8.  Scroll down to the **Request Headers** section.
-9.  Find the `Authorization` header. The value will look like `Bearer [long_string_of_characters]`.
-10. **Copy only the long string of characters** (the token itself), *without* the word `Bearer `.
-
-Example (Copy the whole string)
-https://i.imgur.com/PQtOIM5.jpeg
-
-
-**Important:** Your token is like a password. **Do not share it with anyone.**
-
-### Step 2: Run the Script
-
-Open your terminal or command prompt, navigate to the script's directory, and run it using the following command structure.
-
-**Basic Usage (downloads audio only):**
 ```bash
-python suno_downloader.py --token "your_token_here"
+pip install -r requirements.txt
 ```
-This will download all songs into a new folder named `suno-downloads`.
 
-**Full-Featured Usage (with thumbnails and a custom directory):**
+## Get your Suno token
+
+1. Open `https://suno.com` and sign in.
+2. Open browser DevTools -> Network.
+3. Refresh the page and find a request to feed API (`/api/feed/v2?...`).
+4. In request headers, copy `Authorization: Bearer ...`.
+5. Save only the token string (without `Bearer `) in `token.txt`.
+
+`token.txt` is read automatically by `progress_check.py` and `targeted_update.py` if `--token` is not passed.
+
+## Recommended workflow (reliable + fast)
+
+### 1) Refresh status with smart cache head sync
+
 ```bash
-python suno_downloader.py --token "your_token_here" --directory "My Suno Music" --with-thumbnail
+python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
 ```
-This will download all songs and their thumbnails into a folder named `My Suno Music`.
 
-### Command-Line Arguments
+What this does:
 
-- `--token` **(Required)**: Your Suno authorization token.
-- `--directory` (Optional): The local directory where files will be saved. Defaults to `suno-downloads`.
-- `--with-thumbnail` (Optional): A flag to download and embed the song's cover art.
-- `--proxy` (Optional): A proxy server URL (e.g., `http://user:pass@127.0.0.1:8080`). You can provide multiple proxies separated by commas.
+- Checks newest live pages first and pushes cache forward when new songs are found.
+- Uses cached pages for the full scan to stay fast.
+- Writes:
+  - `out/progress_summary.json`
+  - `out/progress_missing.txt`
+  - `out/progress_extra.txt`
+  - `out/progress_check.log`
 
-## Disclaimer
+### 2) Download all currently-missing files
 
-This is an unofficial tool and is not affiliated with Suno, Inc. It is intended for personal use only to back up your own creations. Please respect Suno's Terms of Service. The developers of this script are not responsible for any misuse.
+```bash
+python3 targeted_update.py --once --max-retries 8 --download-sleep 0.05
+```
 
-## License
+Important behavior:
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+- `--once` is drain mode: it runs immediate cycles until missing files are cleared (or no eligible downloads remain).
+- `--max-downloads` now defaults to `0` (unlimited per cycle), so it attempts all identified missing files each cycle.
+- It does **not** block re-downloads using stale downloaded-id state, so previously removed files can be recovered.
+
+### 3) Verify clean
+
+```bash
+python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
+```
+
+Clean state means in `out/progress_summary.json`:
+
+- `missing_titles = 0`
+- `extra_titles = 0`
+
+## Expected workflow (daily operation)
+
+Use this every time you want the local folder fully synchronized:
+
+1. Run a status + cache-head sync pass.
+2. Run targeted drain download to pull every missing file currently identified.
+3. Run a final status check and confirm clean summary.
+
+Commands:
+
+```bash
+python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
+python3 targeted_update.py --once --max-retries 8 --download-sleep 0.05
+python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
+```
+
+Expected final result in `out/progress_summary.json`:
+
+- `complete_api_fetch: true`
+- `missing_titles: 0`
+- `extra_titles: 0`
+
+If new songs are created while this is running, run the same 3 commands again.
+
+## Continuous sync mode
+
+Terminal A:
+
+```bash
+python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
+```
+
+Terminal B:
+
+```bash
+python3 targeted_update.py --poll-interval 5 --stop-when-clean --max-retries 8 --download-sleep 0.05
+```
+
+This keeps downloading missing tracks while cache is being updated.
+
+## Script reference
+
+### `progress_check.py`
+
+Key options:
+
+- `--refresh`: ignore cache and refetch everything
+- `--head-sync-pages N`: number of live head pages to probe before using cache
+- `--max-retries N`: retries per page (`0` = infinite)
+- `--fail-on-partial`: exits non-zero if feed did not complete
+
+### `targeted_update.py`
+
+Key options:
+
+- `--once`: drain cycles then exit
+- `--max-downloads N`: per-cycle cap (`0` = all missing, default)
+- `--max-retries N`: retries per clip (`0` = infinite)
+- `--stop-when-clean`: exit when no missing files and `progress_check` is complete
+- `--dry-run`: show planned downloads without writing files
+
+### `Suno_downloader.py`
+
+Example:
+
+```bash
+python3 Suno_downloader.py --token "YOUR_TOKEN" --directory "suno-downloads" --with-thumbnail
+```
+
+Options:
+
+- `--token` (required)
+- `--directory`
+- `--with-thumbnail`
+- `--proxy`
+
+## Output files
+
+All operational artifacts are in `out/`:
+
+- `out/api_cache/page_XXXX.json`
+- `out/progress_check.log`
+- `out/progress_summary.json`
+- `out/progress_missing.txt`
+- `out/progress_extra.txt`
+- `out/targeted_update.log`
+- `out/targeted_update_state.json`
+
+## Troubleshooting
+
+- `401` / `403`
+  - Token expired/invalid. Re-export token from browser and retry.
+- `429`
+  - Rate limiting. Scripts auto-retry with backoff; reduce aggressiveness if needed (`--sleep`, `--download-sleep`).
+- DNS / reachability errors
+  - Network/VPN/DNS issue; scripts log warnings and retry.
+- New songs not appearing
+  - Run `progress_check.py` with head sync enabled (default behavior) or use `--refresh` for full recache.
+
+## Notes
+
+- This is an unofficial toolset and not affiliated with Suno.
+- Use it for your own content and in compliance with Suno terms.

--- a/Suno_downloader.py
+++ b/Suno_downloader.py
@@ -1,9 +1,11 @@
+#!/usr/bin/env python3
 import argparse
-import os
 import random
 import re
 import sys
 import time
+from collections import Counter
+from pathlib import Path
 
 import requests
 from colorama import Fore, init
@@ -13,174 +15,434 @@ from mutagen.mp3 import MP3
 init(autoreset=True)
 
 FILENAME_BAD_CHARS = r'[<>:"/\\|?*\x00-\x1F]'
+VERSIONED_NAME_RE = re.compile(r"^(.*) v(\d+)$")
 UNTITLED_PREFIX = "Untitled"
 LIKED_PREFIX = "(Liked) "
+
 
 def sanitize_filename(name, maxlen=200):
     safe = re.sub(FILENAME_BAD_CHARS, "_", name)
     safe = safe.strip(" .")
     return safe[:maxlen] if len(safe) > maxlen else safe
 
+
 def clip_is_liked(clip):
     return bool(clip.get("is_liked"))
+
 
 def apply_liked_prefix(name, liked):
     if not liked:
         return name
     if name.startswith(LIKED_PREFIX):
         return name
-    return f"{LIKED_PREFIX}{name}"
+    return sanitize_filename(f"{LIKED_PREFIX}{name}")
+
 
 def clip_filename_base(clip):
     raw_title = clip.get("title")
     title = raw_title.strip() if isinstance(raw_title, str) else ""
     if title:
-        base = apply_liked_prefix(title, clip_is_liked(clip))
-    else:
-        clip_id = clip.get("id") or "unknown"
-        created_at = clip.get("created_at") or ""
-        date_part = created_at[:10] if isinstance(created_at, str) and len(created_at) >= 10 else "unknown-date"
-        untitled = f"{UNTITLED_PREFIX} {date_part} {clip_id[:8]}"
-        base = apply_liked_prefix(untitled, clip_is_liked(clip))
-    return sanitize_filename(base)
+        return apply_liked_prefix(sanitize_filename(title), clip_is_liked(clip))
+
+    clip_id = clip.get("id") or "unknown"
+    created_at = clip.get("created_at") or ""
+    date_part = created_at[:10] if isinstance(created_at, str) and len(created_at) >= 10 else "unknown-date"
+    untitled = sanitize_filename(f"{UNTITLED_PREFIX} {date_part} {clip_id[:8]}")
+    return apply_liked_prefix(untitled, clip_is_liked(clip))
+
+
+def display_title(clip):
+    raw_title = clip.get("title")
+    title = raw_title.strip() if isinstance(raw_title, str) else ""
+    if title:
+        return apply_liked_prefix(title, clip_is_liked(clip))
+    return clip_filename_base(clip)
+
 
 def pick_proxy_dict(proxies_list):
-    if not proxies_list: return None
+    if not proxies_list:
+        return None
     proxy = random.choice(proxies_list)
     return {"http": proxy, "https": proxy}
 
+
+def reserve_unique_path(out_dir, base_name):
+    first = out_dir / f"{base_name}.mp3"
+    if not first.exists():
+        return first
+    n = 2
+    while True:
+        candidate = out_dir / f"{base_name} v{n}.mp3"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+def count_local_mp3_by_base(out_dir):
+    counts = Counter()
+    for path in out_dir.glob("*.mp3"):
+        stem = path.stem
+        m = VERSIONED_NAME_RE.match(stem)
+        base = m.group(1) if m else stem
+        counts[base] += 1
+    return counts
+
+
 def embed_metadata(mp3_path, image_url=None, title=None, artist=None, proxies_list=None, token=None, timeout=15):
+    if not image_url:
+        return
+
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     proxy_dict = pick_proxy_dict(proxies_list)
     r = requests.get(image_url, proxies=proxy_dict, headers=headers, timeout=timeout)
     r.raise_for_status()
     image_bytes = r.content
     mime = r.headers.get("Content-Type", "image/jpeg").split(";")[0]
-    
-    audio = MP3(mp3_path, ID3=ID3)
-    try: audio.add_tags()
-    except error: pass
 
-    if title: audio.tags["TIT2"] = TIT2(encoding=3, text=title)
-    if artist: audio.tags["TPE1"] = TPE1(encoding=3, text=artist)
+    audio = MP3(mp3_path, ID3=ID3)
+    try:
+        audio.add_tags()
+    except error:
+        pass
+
+    if title:
+        audio.tags["TIT2"] = TIT2(encoding=3, text=title)
+    if artist:
+        audio.tags["TPE1"] = TPE1(encoding=3, text=artist)
 
     for key in list(audio.tags.keys()):
-        if key.startswith("APIC"): del audio.tags[key]
+        if key.startswith("APIC"):
+            del audio.tags[key]
 
     audio.tags.add(APIC(encoding=3, mime=mime, type=3, desc="Cover", data=image_bytes))
     audio.save(v2_version=3)
 
-def extract_private_song_info(token_string, proxies_list=None):
-    print(f"{Fore.CYAN}Extracting private songs using Authorization Token...")
-    base_api_url = "https://studio-api.prod.suno.com/api/feed/v2?hide_disliked=true&hide_gen_stems=true&hide_studio_clips=true&page="
-    headers = {"Authorization": f"Bearer {token_string}"}
 
-    song_info = {}
-    page = 1
-    
+def load_token(arg_token, token_file):
+    if arg_token:
+        return arg_token.strip()
+    path = Path(token_file)
+    if not path.exists():
+        return None
+    return path.read_text().strip()
+
+
+class AuthFailure(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+        super().__init__(f"authorization failed with status {status_code}")
+
+
+class NonRetryableHTTP(Exception):
+    def __init__(self, page, status_code):
+        self.page = page
+        self.status_code = status_code
+        super().__init__(f"non-retryable HTTP status {status_code} on page {page}")
+
+
+class RetryExceeded(Exception):
+    def __init__(self, page, last_error):
+        self.page = page
+        self.last_error = last_error
+        super().__init__(f"exceeded max retries on page {page}: {last_error}")
+
+
+def fetch_feed_page(session, page, token, proxies_list, timeout, max_retries, max_backoff, jitter, base_sleep):
+    url = (
+        "https://studio-api.prod.suno.com/api/feed/v2"
+        "?hide_disliked=true&hide_gen_stems=true&hide_studio_clips=true&page="
+        f"{page}"
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    attempt = 0
     while True:
-        api_url = f"{base_api_url}{page}"
+        attempt += 1
         try:
-            print(f"{Fore.MAGENTA}Fetching songs (Page {page})...")
-            response = requests.get(api_url, headers=headers, proxies=pick_proxy_dict(proxies_list), timeout=15)
-            if response.status_code in [401, 403]:
-                print(f"{Fore.RED}Authorization failed (status {response.status_code}). Your token is likely expired or incorrect.")
-                return {}
-            response.raise_for_status()
-            data = response.json()
-        except requests.exceptions.RequestException as e:
-            print(f"{Fore.RED}Request failed on page {page}: {e}")
-            return {}
+            r = session.get(url, headers=headers, proxies=pick_proxy_dict(proxies_list), timeout=timeout)
+            if r.status_code in (401, 403):
+                raise AuthFailure(r.status_code)
+            if r.status_code == 429 or 500 <= r.status_code < 600:
+                raise requests.HTTPError(f"retryable status {r.status_code}")
+            if 400 <= r.status_code < 500:
+                raise NonRetryableHTTP(page, r.status_code)
+            r.raise_for_status()
+            data = r.json()
+            batch = data if isinstance(data, list) else data.get("clips", [])
+            return batch
+        except (requests.RequestException, ValueError) as e:
+            if max_retries and attempt > max_retries:
+                raise RetryExceeded(page, e) from e
+            wait = min(max_backoff, (2 ** (attempt - 1)) * base_sleep)
+            wait += random.uniform(0, jitter)
+            print(f"{Fore.YELLOW}Retrying page {page} in {wait:.1f}s (attempt {attempt}): {e}")
+            time.sleep(wait)
 
-        clips = data if isinstance(data, list) else data.get("clips", [])
-        if not clips:
-            print(f"{Fore.YELLOW}No more clips found on page {page}.")
+
+def dedupe_clips_by_id(clips):
+    seen = set()
+    deduped = []
+    for clip in clips:
+        clip_id = clip.get("id")
+        if not clip_id:
+            continue
+        if clip_id in seen:
+            continue
+        seen.add(clip_id)
+        deduped.append(clip)
+    return deduped
+
+
+def fetch_all_clips(token, proxies_list, args):
+    print(f"{Fore.CYAN}Extracting private songs using Authorization Token...")
+
+    session = requests.Session()
+    clips = []
+    page = 0
+    complete = False
+    stop_reason = ""
+
+    while True:
+        if args.max_pages and page >= args.max_pages:
+            stop_reason = f"max_pages:{args.max_pages}"
             break
 
-        print(f"{Fore.GREEN}Found {len(clips)} clips on page {page}.")
-        for clip in clips:
-            uuid, audio_url, image_url = clip.get("id"), clip.get("audio_url"), clip.get("image_url")
-            if (uuid and audio_url) and uuid not in song_info:
-                raw_title = clip.get("title")
-                title = raw_title.strip() if isinstance(raw_title, str) else ""
-                display_title = apply_liked_prefix(title, clip_is_liked(clip)) if title else clip_filename_base(clip)
-                song_info[uuid] = {
-                    "title": title,
-                    "audio_url": audio_url,
-                    "image_url": image_url,
-                    "display_name": clip.get("display_name"),
-                    "filename_base": clip_filename_base(clip),
-                    "display_title": display_title,
-                }
+        print(f"{Fore.MAGENTA}Fetching songs (Page {page})...")
+        try:
+            batch = fetch_feed_page(
+                session=session,
+                page=page,
+                token=token,
+                proxies_list=proxies_list,
+                timeout=args.timeout,
+                max_retries=args.max_retries,
+                max_backoff=args.max_backoff,
+                jitter=args.jitter,
+                base_sleep=args.sleep,
+            )
+        except AuthFailure as e:
+            print(f"{Fore.RED}Authorization failed (status {e.status_code}). Token is likely expired/invalid.")
+            return [], False, f"auth_failed:{e.status_code}"
+        except NonRetryableHTTP as e:
+            print(f"{Fore.RED}{e}")
+            stop_reason = f"http_{e.status_code}_page:{e.page}"
+            break
+        except RetryExceeded as e:
+            print(f"{Fore.RED}{e}")
+            stop_reason = f"retry_exceeded_page:{e.page}"
+            break
+
+        if not batch:
+            print(f"{Fore.YELLOW}No more clips found on page {page}.")
+            complete = True
+            stop_reason = f"end_of_feed_page:{page}"
+            break
+
+        clips.extend(batch)
+        print(f"{Fore.GREEN}Found {len(batch)} clips on page {page}. Total so far: {len(clips)}")
         page += 1
-        time.sleep(5)
-    return song_info
+        time.sleep(args.sleep)
 
-def get_unique_filename(filename):
-    if not os.path.exists(filename): return filename
-    name, extn = os.path.splitext(filename)
-    counter = 2
+    deduped = dedupe_clips_by_id(clips)
+    songs = []
+    for clip in deduped:
+        clip_id = clip.get("id")
+        audio_url = clip.get("audio_url")
+        if not clip_id or not audio_url:
+            continue
+        songs.append(
+            {
+                "id": str(clip_id),
+                "title": clip.get("title") or "",
+                "display_title": display_title(clip),
+                "filename_base": clip_filename_base(clip),
+                "audio_url": audio_url,
+                "image_url": clip.get("image_url"),
+                "display_name": clip.get("display_name"),
+                "created_at": clip.get("created_at") or "",
+            }
+        )
+
+    songs.sort(key=lambda c: (c["created_at"], c["id"]))
+    return songs, complete, stop_reason
+
+
+def plan_first_pass_downloads(songs, local_counts):
+    seen_expected = Counter()
+    planned = []
+    skipped_as_existing = 0
+
+    for song in songs:
+        base = song["filename_base"]
+        seen_expected[base] += 1
+        if seen_expected[base] <= local_counts.get(base, 0):
+            skipped_as_existing += 1
+            continue
+        planned.append(song)
+
+    return planned, skipped_as_existing
+
+
+def download_song(session, song, out_dir, token, proxies_list, args):
+    headers = {"Authorization": f"Bearer {token}"}
+    attempt = 0
     while True:
-        new_filename = f"{name} v{counter}{extn}"
-        if not os.path.exists(new_filename): return new_filename
-        counter += 1
+        attempt += 1
+        tmp_path = None
+        try:
+            with session.get(
+                song["audio_url"],
+                stream=True,
+                headers=headers,
+                proxies=pick_proxy_dict(proxies_list),
+                timeout=args.timeout,
+            ) as r:
+                if r.status_code in (401, 403):
+                    return {"ok": False, "fatal_auth": True, "error": f"auth_failed:{r.status_code}"}
+                if r.status_code == 429 or 500 <= r.status_code < 600:
+                    raise requests.HTTPError(f"retryable status {r.status_code}")
+                if 400 <= r.status_code < 500:
+                    return {"ok": False, "fatal_auth": False, "error": f"http_{r.status_code}"}
+                r.raise_for_status()
 
-def download_file(url, filename, proxies_list=None, token=None, timeout=30):
-    # This function now correctly handles finding a unique filename before saving
-    unique_filename = get_unique_filename(filename)
-    
-    headers = {"Authorization": f"Bearer {token}"} if token else {}
-    with requests.get(url, stream=True, proxies=pick_proxy_dict(proxies_list), headers=headers, timeout=timeout) as r:
-        r.raise_for_status()
-        with open(unique_filename, "wb") as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                if chunk: f.write(chunk)
-    return unique_filename
+                out_path = reserve_unique_path(out_dir, song["filename_base"])
+                tmp_path = out_path.with_suffix(out_path.suffix + ".part")
+                with tmp_path.open("wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                tmp_path.replace(out_path)
+                return {"ok": True, "path": out_path}
+        except (requests.RequestException, OSError) as e:
+            if tmp_path and tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+            if args.max_retries and attempt > args.max_retries:
+                return {"ok": False, "fatal_auth": False, "error": str(e)}
+            wait = min(args.max_backoff, (2 ** (attempt - 1)) * args.sleep)
+            wait += random.uniform(0, args.jitter)
+            print(f"{Fore.YELLOW}Retrying clip {song['id']} in {wait:.1f}s (attempt {attempt}): {e}")
+            time.sleep(wait)
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Bulk download your private suno songs")
-    parser.add_argument("--token", type=str, required=True, help="Your Suno session Bearer Token.")
+    base_dir = Path(__file__).resolve().parent
+
+    parser = argparse.ArgumentParser(
+        description="First-pass bulk downloader for Suno (workflow step 1): fetch feed and download currently-missing files."
+    )
+    parser.add_argument("--token", type=str, default=None, help="Suno Bearer token. If omitted, uses --token-file.")
+    parser.add_argument(
+        "--token-file",
+        type=str,
+        default=str(base_dir / "token.txt"),
+        help="Path to token file used when --token is omitted.",
+    )
+    parser.add_argument(
+        "--directory",
+        type=str,
+        default=str(base_dir / "out"),
+        help="Local directory for saving files (default: out).",
+    )
     parser.add_argument("--proxy", type=str, help="Proxy with protocol (comma-separated).")
-    parser.add_argument("--directory", type=str, default="suno-downloads", help="Local directory for saving files.")
-    parser.add_argument("--with-thumbnail", action="store_true", help="Embed the song's thumbnail.")
+    parser.add_argument("--with-thumbnail", action="store_true", help="Embed each song thumbnail into ID3 metadata.")
+    parser.add_argument("--sleep", type=float, default=0.2, help="Base sleep/backoff unit in seconds.")
+    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout in seconds.")
+    parser.add_argument("--max-pages", type=int, default=0, help="Optional max pages to fetch (0 = no limit).")
+    parser.add_argument("--max-retries", type=int, default=8, help="Retries per page/download (0 = infinite).")
+    parser.add_argument("--max-backoff", type=float, default=60.0, help="Maximum backoff in seconds.")
+    parser.add_argument("--jitter", type=float, default=0.3, help="Random jitter added to backoff sleep.")
+    parser.add_argument("--dry-run", action="store_true", help="Build plan only; do not download files.")
+    parser.add_argument("--fail-on-partial", action="store_true", help="Exit non-zero if API fetch did not complete.")
+    parser.add_argument("--fail-on-download-errors", action="store_true", help="Exit non-zero if any downloads fail.")
     args = parser.parse_args()
 
-    songs = extract_private_song_info(args.token, args.proxy.split(",") if args.proxy else None)
-
-    if not songs:
-        print(f"{Fore.RED}No songs found. Please check your token.")
+    token = load_token(args.token, args.token_file)
+    if not token:
+        print(
+            f"{Fore.RED}No token provided. Pass --token or create token file at {args.token_file}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-    if not os.path.exists(args.directory):
-        os.makedirs(args.directory)
+    proxies_list = args.proxy.split(",") if args.proxy else None
+    out_dir = Path(args.directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"\n{Fore.CYAN}--- Starting Download Process ({len(songs)} songs to check) ---")
-    for uuid, obj in songs.items():
-        title = obj.get("display_title") or obj.get("title") or uuid
-        metadata_title = obj.get("title") or obj.get("filename_base") or uuid
-        fname = obj.get("filename_base", sanitize_filename(title)) + ".mp3"
-        out_path = os.path.join(args.directory, fname)
+    songs, complete_api_fetch, stop_reason = fetch_all_clips(token, proxies_list, args)
+    if stop_reason.startswith("auth_failed"):
+        sys.exit(1)
+    if not songs:
+        print(f"{Fore.YELLOW}No clips discovered from API.")
+        if args.fail_on_partial and not complete_api_fetch:
+            sys.exit(2)
+        sys.exit(0)
 
-        print(f"Processing: {Fore.GREEN}🎵 {title}")
-        try:
-            # FIX: The old 'if os.path.exists' check was removed from here.
-            # We now call download_file directly and let it handle unique filenames.
-            
-            print(f"  -> Downloading...")
-            saved_path = download_file(obj["audio_url"], out_path, token=args.token)
-            
-            if args.with_thumbnail and obj.get("image_url"):
-                print(f"  -> Embedding thumbnail...")
-                embed_metadata(saved_path, image_url=obj["image_url"], token=args.token, artist=obj.get("display_name"), title=metadata_title)
-            
-            # Let the user know if a new version was created
-            if os.path.basename(saved_path) != os.path.basename(out_path):
-                print(f"{Fore.YELLOW}  -> Saved as new version: {os.path.basename(saved_path)}")
+    local_counts = count_local_mp3_by_base(out_dir)
+    plan, skipped_as_existing = plan_first_pass_downloads(songs, local_counts)
 
-        except Exception as e:
-            print(f"{Fore.RED}Failed on {title}: {e}")
+    print(f"\n{Fore.CYAN}--- First-Pass Download Plan ---")
+    print(f"{Fore.CYAN}API unique clips: {len(songs)}")
+    print(f"{Fore.CYAN}Local files detected: {sum(local_counts.values())}")
+    print(f"{Fore.CYAN}Assumed already present by title count: {skipped_as_existing}")
+    print(f"{Fore.CYAN}Planned downloads: {len(plan)}")
+    print(f"{Fore.CYAN}API fetch complete: {complete_api_fetch} ({stop_reason})")
 
-    print(f"\n{Fore.BLUE}Download process complete. Files are in '{args.directory}'.")
+    if args.dry_run:
+        for song in plan[:25]:
+            print(f"{Fore.YELLOW}DRY RUN: {song['display_title']} -> {song['filename_base']}.mp3")
+        if len(plan) > 25:
+            print(f"{Fore.YELLOW}... and {len(plan) - 25} more")
+        sys.exit(0)
+
+    session = requests.Session()
+    downloaded = 0
+    failed = 0
+    fatal_auth = False
+
+    print(f"\n{Fore.CYAN}--- Starting Download Process ({len(plan)} planned) ---")
+    for song in plan:
+        print(f"Processing: {Fore.GREEN}{song['display_title']}")
+        result = download_song(session, song, out_dir, token, proxies_list, args)
+        if not result.get("ok"):
+            failed += 1
+            if result.get("fatal_auth"):
+                fatal_auth = True
+            print(f"{Fore.RED}  -> Failed: {result.get('error')}")
+            continue
+
+        downloaded += 1
+        saved_path = result["path"]
+        print(f"{Fore.GREEN}  -> Downloaded: {saved_path.name}")
+
+        if args.with_thumbnail and song.get("image_url"):
+            try:
+                embed_metadata(
+                    saved_path,
+                    image_url=song["image_url"],
+                    token=token,
+                    artist=song.get("display_name"),
+                    title=song.get("title") or song["filename_base"],
+                    proxies_list=proxies_list,
+                    timeout=args.timeout,
+                )
+                print(f"{Fore.GREEN}  -> Embedded thumbnail")
+            except Exception as e:
+                print(f"{Fore.YELLOW}  -> Thumbnail embed skipped: {e}")
+
+    print(f"\n{Fore.BLUE}--- Summary ---")
+    print(f"{Fore.BLUE}Downloaded: {downloaded}")
+    print(f"{Fore.BLUE}Failed: {failed}")
+    print(f"{Fore.BLUE}Output directory: {out_dir}")
+    print(f"{Fore.BLUE}API fetch complete: {complete_api_fetch} ({stop_reason})")
+
+    if fatal_auth:
+        sys.exit(1)
+    if args.fail_on_partial and not complete_api_fetch:
+        sys.exit(2)
+    if args.fail_on_download_errors and failed > 0:
+        sys.exit(3)
     sys.exit(0)
 
 

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,51 @@
+# progress_check.py notes
+
+This script is a durable, resumable checker for Suno downloads. It fetches the full feed from the Suno API, compares it to the local `out/` folder, and writes all logs and reports inside the repo.
+
+## What it writes
+- `out/progress_check.log`
+- `out/progress_summary.json`
+- `out/progress_missing.txt`
+- `out/progress_extra.txt`
+- `out/api_cache/` (one JSON file per page so it can resume without re-fetching)
+
+## How it avoids timeouts
+- Each page is cached on disk in `out/api_cache/`.
+- If a request fails or hits `429`, the script retries with exponential backoff plus jitter.
+- The script can run indefinitely (default), so it keeps retrying until it finishes.
+
+## How to run
+```bash
+/root/mobile-dev/Suno_DownloadEverything/.venv/bin/python /root/mobile-dev/Suno_DownloadEverything/progress_check.py --out-dir /root/mobile-dev/Suno_DownloadEverything/out
+```
+
+## Resetting the cache
+If you want a clean re-fetch, delete the cache folder or pass `--refresh`:
+```bash
+rm -rf /root/mobile-dev/Suno_DownloadEverything/out/api_cache
+# or
+/root/mobile-dev/Suno_DownloadEverything/.venv/bin/python /root/mobile-dev/Suno_DownloadEverything/progress_check.py --refresh
+```
+
+## Notes on counts
+The script compares by sanitized title, the same way the downloader builds filenames. If multiple clips share the same title, the script expects multiple files with the same base name, using the downloader's `v2`, `v3` naming scheme.
+If a clip has `is_liked=true`, filenames are prefixed with `(Liked) ` (for example, `(Liked) Song Name.mp3`).
+
+## Targeted missing downloader (while progress_check runs)
+Use `targeted_update.py` in a second terminal to continuously download only files currently missing from `out/` based on `out/api_cache/` pages.
+
+```bash
+/root/mobile-dev/Suno_DownloadEverything/.venv/bin/python /root/mobile-dev/Suno_DownloadEverything/targeted_update.py --out-dir /root/mobile-dev/Suno_DownloadEverything/out --poll-interval 5 --stop-when-clean
+```
+
+`targeted_update.py` now treats `--max-downloads 0` as unlimited (default), and `--once` runs in drain mode until missing files are cleared or no eligible downloads remain.
+
+Useful safety flags:
+
+```bash
+# one planning pass, no downloads
+/root/mobile-dev/Suno_DownloadEverything/.venv/bin/python /root/mobile-dev/Suno_DownloadEverything/targeted_update.py --out-dir /root/mobile-dev/Suno_DownloadEverything/out --once --dry-run
+
+# stop if no progress for N cycles
+/root/mobile-dev/Suno_DownloadEverything/.venv/bin/python /root/mobile-dev/Suno_DownloadEverything/targeted_update.py --out-dir /root/mobile-dev/Suno_DownloadEverything/out --max-idle-cycles 20
+```

--- a/progress_check.py
+++ b/progress_check.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import random
+import re
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+FILENAME_BAD_CHARS = r'[<>:"/\\|?*\x00-\x1F]'
+UNTITLED_PREFIX = "Untitled"
+LIKED_PREFIX = "(Liked) "
+CACHE_PAGE_SIZE = 20
+
+
+def sanitize_filename(name, maxlen=200):
+    safe = re.sub(FILENAME_BAD_CHARS, "_", name)
+    safe = safe.strip(" .")
+    return safe[:maxlen] if len(safe) > maxlen else safe
+
+
+def clip_is_liked(clip):
+    return bool(clip.get("is_liked"))
+
+
+def apply_liked_prefix(name, liked):
+    if not liked:
+        return name
+    if name.startswith(LIKED_PREFIX):
+        return name
+    return sanitize_filename(f"{LIKED_PREFIX}{name}")
+
+
+def utc_ts():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def is_dns_error(err):
+    text = str(err)
+    return "NameResolutionError" in text or "Failed to resolve" in text
+
+
+class AuthFailure(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+        super().__init__(f"auth failed with status {status_code}")
+
+
+class NonRetryableHTTP(Exception):
+    def __init__(self, page, status_code):
+        self.page = page
+        self.status_code = status_code
+        super().__init__(f"non-retryable HTTP status {status_code} on page {page}")
+
+
+class RetryExceeded(Exception):
+    def __init__(self, page, last_error):
+        self.page = page
+        self.last_error = last_error
+        super().__init__(f"exceeded max retries on page {page}: {last_error}")
+
+
+def clip_base_name(clip):
+    raw_title = clip.get("title")
+    title = raw_title.strip() if isinstance(raw_title, str) else ""
+    if title:
+        return apply_liked_prefix(sanitize_filename(title), clip_is_liked(clip))
+
+    clip_id = clip.get("id") or "unknown"
+    created_at = clip.get("created_at") or ""
+    date_part = created_at[:10] if isinstance(created_at, str) and len(created_at) >= 10 else "unknown-date"
+    untitled = sanitize_filename(f"{UNTITLED_PREFIX} {date_part} {clip_id[:8]}")
+    return apply_liked_prefix(untitled, clip_is_liked(clip))
+
+
+def clip_id(clip):
+    value = clip.get("id")
+    return str(value) if value else None
+
+
+def dedupe_clips_by_id(clips):
+    seen_ids = set()
+    deduped = []
+    for clip in clips:
+        cid = clip_id(clip)
+        if cid and cid in seen_ids:
+            continue
+        if cid:
+            seen_ids.add(cid)
+        deduped.append(clip)
+    return deduped
+
+
+def load_cached_clips(cache_dir):
+    clips = []
+    for cache_file in sorted(cache_dir.glob("page_*.json")):
+        try:
+            data = json.loads(cache_file.read_text())
+        except Exception:
+            continue
+        batch = data if isinstance(data, list) else data.get("clips", [])
+        if not isinstance(batch, list):
+            continue
+        if not batch:
+            break
+        clips.extend(batch)
+    return dedupe_clips_by_id(clips)
+
+
+def rewrite_cache_clips(cache_dir, clips):
+    for old in cache_dir.glob("page_*.json"):
+        old.unlink()
+
+    if not clips:
+        (cache_dir / "page_0001.json").write_text(json.dumps({"clips": []}))
+        return
+
+    page = 1
+    for i in range(0, len(clips), CACHE_PAGE_SIZE):
+        chunk = clips[i:i + CACHE_PAGE_SIZE]
+        (cache_dir / f"page_{page:04d}.json").write_text(json.dumps({"clips": chunk}))
+        page += 1
+
+    (cache_dir / f"page_{page:04d}.json").write_text(json.dumps({"clips": []}))
+
+
+def fetch_live_page(session, base_api_url, headers, page, args, log):
+    attempt = 0
+    while True:
+        try:
+            r = session.get(base_api_url + str(page), headers=headers, timeout=args.timeout)
+            if r.status_code in (401, 403):
+                raise AuthFailure(r.status_code)
+            if r.status_code == 429 or 500 <= r.status_code < 600:
+                raise requests.HTTPError(f"retryable status {r.status_code}")
+            if 400 <= r.status_code < 500:
+                raise NonRetryableHTTP(page, r.status_code)
+            r.raise_for_status()
+            data = r.json()
+            batch = data if isinstance(data, list) else data.get("clips", [])
+            return data, batch
+        except (requests.RequestException, ValueError) as e:
+            attempt += 1
+            if args.max_retries and attempt > args.max_retries:
+                raise RetryExceeded(page, e) from e
+            if attempt == 1 and is_dns_error(e):
+                log("WARN: DNS resolution failed; check network/VPN/DNS settings.")
+            backoff = min(args.max_backoff, (2 ** (attempt - 1)) * args.sleep)
+            backoff += random.uniform(0, args.jitter)
+            log(f"Retrying page {page} in {backoff:.1f}s (attempt {attempt}): {e}")
+            time.sleep(backoff)
+
+
+def sync_cache_head(session, base_api_url, headers, cache_dir, args, log):
+    cached_clips = load_cached_clips(cache_dir)
+    if not cached_clips:
+        return {"status": "empty_cache", "shifted_clips": 0}
+
+    cached_ids = {clip_id(c) for c in cached_clips if clip_id(c)}
+    live_prefix = []
+    anchor_found = False
+
+    for page in range(1, args.head_sync_pages + 1):
+        _, batch = fetch_live_page(session, base_api_url, headers, page, args, log)
+        if not batch:
+            rewrite_cache_clips(cache_dir, [])
+            return {"status": "feed_empty", "shifted_clips": len(cached_clips)}
+
+        for clip in batch:
+            cid = clip_id(clip)
+            if cid and cid in cached_ids:
+                anchor_found = True
+                break
+            live_prefix.append(clip)
+        if anchor_found:
+            break
+
+    if not anchor_found:
+        return {"status": "no_overlap_refresh", "shifted_clips": 0}
+
+    merged = dedupe_clips_by_id(live_prefix + cached_clips)
+    shifted_clips = max(0, len(merged) - len(cached_clips))
+    if shifted_clips > 0:
+        rewrite_cache_clips(cache_dir, merged)
+        return {"status": "shifted", "shifted_clips": shifted_clips}
+    return {"status": "up_to_date", "shifted_clips": 0}
+
+
+def main():
+    base_dir = Path(__file__).resolve().parent
+
+    parser = argparse.ArgumentParser(
+        description="Progressively check Suno downloads vs API with retry backoff and on-disk cache."
+    )
+    parser.add_argument("--token", type=str, default=None, help="Bearer token. If omitted, uses token.txt.")
+    parser.add_argument("--token-file", type=str, default=str(base_dir / "token.txt"), help="Path to token file.")
+    parser.add_argument("--out-dir", type=str, default=str(base_dir / "out"), help="Download/output directory.")
+    parser.add_argument("--cache-dir", type=str, default=None, help="Cache directory for API pages.")
+    parser.add_argument("--refresh", action="store_true", help="Ignore cache and refetch all pages.")
+    parser.add_argument("--sleep", type=float, default=1.0, help="Base sleep between successful page requests.")
+    parser.add_argument("--timeout", type=float, default=20.0, help="HTTP timeout in seconds.")
+    parser.add_argument("--max-pages", type=int, default=0, help="Optional max pages to fetch (0 = no limit).")
+    parser.add_argument("--max-retries", type=int, default=12, help="Max retries per page (0 = infinite).")
+    parser.add_argument("--max-backoff", type=float, default=120.0, help="Maximum backoff sleep in seconds.")
+    parser.add_argument("--jitter", type=float, default=0.5, help="Random jitter added to backoff sleep.")
+    parser.add_argument(
+        "--head-sync-pages",
+        type=int,
+        default=5,
+        help="When using cache, probe this many live head pages and push cache forward (0 disables).",
+    )
+    parser.add_argument(
+        "--fail-on-partial",
+        action="store_true",
+        help="Exit with code 2 if API fetch did not complete to end-of-feed.",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cache_dir = Path(args.cache_dir) if args.cache_dir else (out_dir / "api_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    log_path = out_dir / "progress_check.log"
+
+    def log(msg):
+        line = f"[{utc_ts()}] {msg}"
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        print(line)
+
+    token = args.token
+    if not token:
+        token_file = Path(args.token_file)
+        if not token_file.exists():
+            log(f"ERROR: token file not found at {token_file}")
+            raise SystemExit(1)
+        token = token_file.read_text().strip()
+
+    base_api_url = (
+        "https://studio-api.prod.suno.com/api/feed/v2"
+        "?hide_disliked=true&hide_gen_stems=true&hide_studio_clips=true&page="
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    session = requests.Session()
+
+    log("Starting API fetch...")
+
+    cache_head_sync = "disabled_by_flag" if args.head_sync_pages <= 0 else "skipped"
+    cache_head_shifted_clips = 0
+
+    if not args.refresh and args.head_sync_pages > 0 and any(cache_dir.glob("page_*.json")):
+        try:
+            sync_result = sync_cache_head(session, base_api_url, headers, cache_dir, args, log)
+            cache_head_sync = sync_result["status"]
+            cache_head_shifted_clips = sync_result.get("shifted_clips", 0)
+            if cache_head_sync == "shifted":
+                log(f"Cache head sync inserted {cache_head_shifted_clips} new clip(s) at the front.")
+            if cache_head_sync == "no_overlap_refresh":
+                log(
+                    f"No cache overlap found in first {args.head_sync_pages} live pages; "
+                    "falling back to full refresh."
+                )
+                for old in cache_dir.glob("page_*.json"):
+                    old.unlink()
+                args.refresh = True
+        except AuthFailure as e:
+            log(f"ERROR: auth failed with status {e.status_code}")
+            raise SystemExit(1)
+        except NonRetryableHTTP as e:
+            log(f"ERROR: non-retryable HTTP status {e.status_code} on page {e.page} during head sync")
+            raise SystemExit(1)
+        except RetryExceeded as e:
+            log(f"ERROR: exceeded max retries on page {e.page} during head sync: {e.last_error}")
+            raise SystemExit(1)
+    elif args.refresh:
+        cache_head_sync = "skipped_refresh_mode"
+
+    page = 1
+    clips = []
+    complete = True
+    stop_reason = "end_of_feed"
+
+    while True:
+        if args.max_pages and page > args.max_pages:
+            log(f"Reached max-pages limit: {args.max_pages}")
+            complete = False
+            stop_reason = f"max_pages_reached:{args.max_pages}"
+            break
+
+        cache_file = cache_dir / f"page_{page:04d}.json"
+
+        if cache_file.exists() and not args.refresh:
+            try:
+                data = json.loads(cache_file.read_text())
+                batch = data if isinstance(data, list) else data.get("clips", [])
+                if not batch:
+                    log(f"No more clips at page {page}.")
+                    stop_reason = f"end_of_feed_page:{page}"
+                    break
+                clips.extend(batch)
+                log(f"Loaded page {page} from cache: {len(batch)} clips (total {len(clips)})")
+                page += 1
+                time.sleep(args.sleep)
+                continue
+            except Exception as e:
+                log(f"WARN: failed to read cache for page {page}: {e}. Refetching...")
+
+        batch = None
+        while True:
+            try:
+                data, batch = fetch_live_page(session, base_api_url, headers, page, args, log)
+                cache_file.write_text(json.dumps(data))
+
+                if not batch:
+                    log(f"No more clips at page {page}.")
+                    stop_reason = f"end_of_feed_page:{page}"
+                    break
+
+                clips.extend(batch)
+                log(f"Fetched page {page}: {len(batch)} clips (total {len(clips)})")
+                page += 1
+                time.sleep(args.sleep)
+                break
+            except AuthFailure as e:
+                log(f"ERROR: auth failed with status {e.status_code}")
+                complete = False
+                stop_reason = f"auth_failed:{e.status_code}"
+                break
+            except NonRetryableHTTP as e:
+                log(f"ERROR: non-retryable HTTP status {e.status_code} on page {e.page}")
+                complete = False
+                stop_reason = f"http_{e.status_code}_page:{e.page}"
+                break
+            except RetryExceeded as e:
+                log(f"ERROR: exceeded max retries on page {e.page}: {e.last_error}")
+                complete = False
+                stop_reason = f"max_retries_exceeded_page:{e.page}"
+                break
+
+        # end while for attempts
+
+        if batch == []:
+            break
+        if stop_reason.startswith("auth_failed") or stop_reason.startswith("http_") or stop_reason.startswith("max_retries_exceeded"):
+            break
+
+    # summarize expected; dedupe by clip id because feed can contain repeats
+    deduped_clips = []
+    seen_ids = set()
+    for c in clips:
+        clip_id = c.get("id")
+        if clip_id and clip_id in seen_ids:
+            continue
+        if clip_id:
+            seen_ids.add(clip_id)
+        deduped_clips.append(c)
+
+    expected = Counter()
+    for c in deduped_clips:
+        base = clip_base_name(c)
+        expected[base] += 1
+
+    # actual counts by base filename (strip ' vN' suffix)
+    actual = Counter()
+    for p in out_dir.glob("*.mp3"):
+        stem = p.stem
+        m = re.match(r"^(.*) v(\d+)$", stem)
+        base = m.group(1) if m else stem
+        actual[base] += 1
+
+    missing = {base: (need, actual.get(base, 0)) for base, need in expected.items() if actual.get(base, 0) < need}
+    extra = {base: (actual.get(base, 0), expected.get(base, 0)) for base in actual.keys() if actual.get(base, 0) > expected.get(base, 0)}
+
+    missing_path = out_dir / "progress_missing.txt"
+    extra_path = out_dir / "progress_extra.txt"
+    summary_path = out_dir / "progress_summary.json"
+
+    with missing_path.open("w", encoding="utf-8") as f:
+        for base, (need, have) in sorted(missing.items()):
+            f.write(f"{base}\tneed={need}\thave={have}\n")
+
+    with extra_path.open("w", encoding="utf-8") as f:
+        for base, (have, need) in sorted(extra.items()):
+            f.write(f"{base}\thave={have}\texpected={need}\n")
+
+    summary = {
+        "api_clips_raw": len(clips),
+        "api_clips_unique": len(deduped_clips),
+        "unique_titles": len(expected),
+        "local_mp3_files": sum(actual.values()),
+        "missing_titles": len(missing),
+        "extra_titles": len(extra),
+        "complete_api_fetch": complete,
+        "stop_reason": stop_reason,
+        "last_page_reached": page,
+        "output_dir": str(out_dir),
+        "log_file": str(log_path),
+        "missing_file": str(missing_path),
+        "extra_file": str(extra_path),
+        "cache_dir": str(cache_dir),
+        "cache_head_sync": cache_head_sync,
+        "cache_head_shifted_clips": cache_head_shifted_clips,
+        "cache_head_pages_checked": args.head_sync_pages,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2))
+
+    log("--- Summary ---")
+    log(json.dumps(summary))
+    if args.fail_on_partial and not complete:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/progress_check.py
+++ b/progress_check.py
@@ -115,10 +115,10 @@ def rewrite_cache_clips(cache_dir, clips):
         old.unlink()
 
     if not clips:
-        (cache_dir / "page_0001.json").write_text(json.dumps({"clips": []}))
+        (cache_dir / "page_0000.json").write_text(json.dumps({"clips": []}))
         return
 
-    page = 1
+    page = 0
     for i in range(0, len(clips), CACHE_PAGE_SIZE):
         chunk = clips[i:i + CACHE_PAGE_SIZE]
         (cache_dir / f"page_{page:04d}.json").write_text(json.dumps({"clips": chunk}))
@@ -163,7 +163,7 @@ def sync_cache_head(session, base_api_url, headers, cache_dir, args, log):
     live_prefix = []
     anchor_found = False
 
-    for page in range(1, args.head_sync_pages + 1):
+    for page in range(0, args.head_sync_pages):
         _, batch = fetch_live_page(session, base_api_url, headers, page, args, log)
         if not batch:
             rewrite_cache_clips(cache_dir, [])
@@ -281,13 +281,13 @@ def main():
     elif args.refresh:
         cache_head_sync = "skipped_refresh_mode"
 
-    page = 1
+    page = 0
     clips = []
     complete = True
     stop_reason = "end_of_feed"
 
     while True:
-        if args.max_pages and page > args.max_pages:
+        if args.max_pages and page >= args.max_pages:
             log(f"Reached max-pages limit: {args.max_pages}")
             complete = False
             stop_reason = f"max_pages_reached:{args.max_pages}"

--- a/targeted_update.py
+++ b/targeted_update.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import random
+import re
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+FILENAME_BAD_CHARS = r'[<>:"/\\|?*\x00-\x1F]'
+VERSIONED_NAME_RE = re.compile(r"^(.*) v(\d+)$")
+UNTITLED_PREFIX = "Untitled"
+LIKED_PREFIX = "(Liked) "
+
+
+def sanitize_filename(name, maxlen=200):
+    safe = re.sub(FILENAME_BAD_CHARS, "_", name)
+    safe = safe.strip(" .")
+    return safe[:maxlen] if len(safe) > maxlen else safe
+
+
+def clip_is_liked(clip):
+    return bool(clip.get("is_liked"))
+
+
+def apply_liked_prefix(name, liked):
+    if not liked:
+        return name
+    if name.startswith(LIKED_PREFIX):
+        return name
+    return sanitize_filename(f"{LIKED_PREFIX}{name}")
+
+
+def utc_ts():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def is_dns_error(err):
+    text = str(err)
+    return "NameResolutionError" in text or "Failed to resolve" in text
+
+
+def clip_base_name(clip):
+    raw_title = clip.get("title")
+    title = raw_title.strip() if isinstance(raw_title, str) else ""
+    if title:
+        return apply_liked_prefix(sanitize_filename(title), clip_is_liked(clip))
+
+    clip_id = clip.get("id") or "unknown"
+    created_at = clip.get("created_at") or ""
+    date_part = created_at[:10] if isinstance(created_at, str) and len(created_at) >= 10 else "unknown-date"
+    untitled = sanitize_filename(f"{UNTITLED_PREFIX} {date_part} {clip_id[:8]}")
+    return apply_liked_prefix(untitled, clip_is_liked(clip))
+
+
+def display_title(clip):
+    raw_title = clip.get("title")
+    title = raw_title.strip() if isinstance(raw_title, str) else ""
+    if title:
+        return apply_liked_prefix(title, clip_is_liked(clip))
+    return clip_base_name(clip)
+
+
+def load_state(path):
+    if not path.exists():
+        return {"failed_attempts": {}}
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            raise ValueError("state must be an object")
+        failed_attempts = data.get("failed_attempts", {})
+        if not isinstance(failed_attempts, dict):
+            failed_attempts = {}
+        return {
+            "failed_attempts": {str(k): int(v) for k, v in failed_attempts.items() if isinstance(v, int)},
+        }
+    except Exception:
+        return {"failed_attempts": {}}
+
+
+def save_state(path, failed_attempts):
+    payload = {
+        "updated_at": utc_ts(),
+        "failed_attempts": failed_attempts,
+    }
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def reserve_unique_path(out_dir, base_name):
+    first = out_dir / f"{base_name}.mp3"
+    if not first.exists():
+        return first
+    n = 2
+    while True:
+        candidate = out_dir / f"{base_name} v{n}.mp3"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+def count_local_mp3_by_base(out_dir):
+    counts = Counter()
+    for path in out_dir.glob("*.mp3"):
+        stem = path.stem
+        m = VERSIONED_NAME_RE.match(stem)
+        base = m.group(1) if m else stem
+        counts[base] += 1
+    return counts
+
+
+def load_cache_clips(cache_dir):
+    expected = Counter()
+    clips_by_base = defaultdict(list)
+    seen_ids = set()
+    parsed_pages = 0
+    unreadable_pages = 0
+
+    for page_path in sorted(cache_dir.glob("page_*.json")):
+        try:
+            data = json.loads(page_path.read_text())
+        except Exception:
+            unreadable_pages += 1
+            continue
+        parsed_pages += 1
+
+        batch = data if isinstance(data, list) else data.get("clips", [])
+        if not isinstance(batch, list):
+            continue
+
+        for clip in batch:
+            clip_id = clip.get("id")
+            audio_url = clip.get("audio_url")
+            if not clip_id or not audio_url:
+                continue
+            if clip_id in seen_ids:
+                continue
+            seen_ids.add(clip_id)
+
+            title = display_title(clip)
+            base = clip_base_name(clip)
+
+            expected[base] += 1
+            clips_by_base[base].append(
+                {
+                    "id": clip_id,
+                    "title": title,
+                    "base": base,
+                    "audio_url": audio_url,
+                    "created_at": clip.get("created_at") or "",
+                }
+            )
+
+    for base in clips_by_base:
+        clips_by_base[base].sort(key=lambda c: (c["created_at"], c["id"]))
+
+    return expected, clips_by_base, parsed_pages, unreadable_pages
+
+
+def load_missing_hints(missing_file):
+    if not missing_file.exists():
+        return []
+    hinted = []
+    for line in missing_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        base = line.split("\t", 1)[0].strip()
+        if base:
+            hinted.append(base)
+    return hinted
+
+
+def progress_fetch_complete(summary_path):
+    if not summary_path.exists():
+        return False
+    try:
+        data = json.loads(summary_path.read_text())
+    except Exception:
+        return False
+    return bool(data.get("complete_api_fetch"))
+
+
+def build_plan(missing_counts, clips_by_base, failed_attempts, hinted_bases, max_downloads, per_clip_max_failures):
+    plan = []
+    hinted_set = set(hinted_bases)
+
+    def sort_key(base_name):
+        return (0 if base_name in hinted_set else 1, base_name)
+
+    for base in sorted(missing_counts.keys(), key=sort_key):
+        need = missing_counts[base]
+        if need <= 0:
+            continue
+        for clip in clips_by_base.get(base, []):
+            clip_id = clip["id"]
+            if failed_attempts.get(clip_id, 0) >= per_clip_max_failures:
+                continue
+            plan.append(clip)
+            need -= 1
+            if need <= 0 or len(plan) >= max_downloads:
+                break
+        if len(plan) >= max_downloads:
+            break
+    return plan
+
+
+def download_clip(session, clip, out_dir, token, timeout, max_retries, max_backoff, jitter, base_sleep, log):
+    headers = {"Authorization": f"Bearer {token}"}
+    clip_id = clip["id"]
+    url = clip["audio_url"]
+    base_name = clip["base"]
+
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            with session.get(url, headers=headers, stream=True, timeout=timeout) as r:
+                if r.status_code in (401, 403):
+                    return {"ok": False, "retryable": False, "error": f"auth_failed:{r.status_code}"}
+                if r.status_code == 429 or 500 <= r.status_code < 600:
+                    raise requests.HTTPError(f"retryable status {r.status_code}")
+                if 400 <= r.status_code < 500:
+                    return {"ok": False, "retryable": False, "error": f"http_{r.status_code}"}
+                r.raise_for_status()
+
+                out_path = reserve_unique_path(out_dir, base_name)
+                with out_path.open("xb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+
+                return {"ok": True, "path": str(out_path), "clip_id": clip_id}
+        except (requests.RequestException, OSError) as e:
+            if max_retries and attempt >= max_retries:
+                return {"ok": False, "retryable": True, "error": str(e)}
+            if attempt == 1 and is_dns_error(e):
+                log("WARN: DNS resolution failed during targeted download; check network/VPN/DNS.")
+            backoff = min(max_backoff, (2 ** (attempt - 1)) * base_sleep)
+            backoff += random.uniform(0, jitter)
+            log(f"Retrying clip {clip_id} in {backoff:.1f}s (attempt {attempt}): {e}")
+            time.sleep(backoff)
+
+
+def resolve_cycle_download_limit(max_downloads, missing_files):
+    # 0 means unlimited for the current cycle.
+    if max_downloads and max_downloads > 0:
+        return max_downloads
+    return max(1, missing_files)
+
+
+def main():
+    base_dir = Path(__file__).resolve().parent
+
+    parser = argparse.ArgumentParser(
+        description="Continuously download only currently-missing files using progress_check cache/output."
+    )
+    parser.add_argument("--token", type=str, default=None, help="Bearer token. If omitted, uses token.txt.")
+    parser.add_argument("--token-file", type=str, default=str(base_dir / "token.txt"), help="Path to token file.")
+    parser.add_argument("--out-dir", type=str, default=str(base_dir / "out"), help="Download/output directory.")
+    parser.add_argument("--cache-dir", type=str, default=None, help="Cache directory for API pages.")
+    parser.add_argument("--state-file", type=str, default=None, help="State file path.")
+    parser.add_argument("--log-file", type=str, default=None, help="Log file path.")
+    parser.add_argument("--poll-interval", type=float, default=5.0, help="Seconds between scan cycles.")
+    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout in seconds.")
+    parser.add_argument(
+        "--max-downloads",
+        type=int,
+        default=0,
+        help="Max downloads per cycle (0 = all currently-missing files).",
+    )
+    parser.add_argument("--download-sleep", type=float, default=0.2, help="Base sleep for retry backoff.")
+    parser.add_argument("--max-retries", type=int, default=8, help="Max retries per clip download (0 = infinite).")
+    parser.add_argument("--max-backoff", type=float, default=60.0, help="Maximum retry backoff in seconds.")
+    parser.add_argument("--jitter", type=float, default=0.3, help="Random jitter added to backoff sleep.")
+    parser.add_argument("--max-idle-cycles", type=int, default=0, help="Stop after N idle cycles (0 = infinite).")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run immediate drain cycles until missing files are cleared (or no eligible downloads remain), then exit.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show planned downloads but do not download.")
+    parser.add_argument(
+        "--stop-when-clean",
+        action="store_true",
+        help="Exit once no missing files remain and progress_summary says API fetch completed.",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = Path(args.cache_dir) if args.cache_dir else (out_dir / "api_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    state_path = Path(args.state_file) if args.state_file else (out_dir / "targeted_update_state.json")
+    log_path = Path(args.log_file) if args.log_file else (out_dir / "targeted_update.log")
+    progress_missing_path = out_dir / "progress_missing.txt"
+    progress_summary_path = out_dir / "progress_summary.json"
+
+    def log(msg):
+        line = f"[{utc_ts()}] {msg}"
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        print(line)
+
+    token = args.token
+    if not token:
+        token_file = Path(args.token_file)
+        if not token_file.exists():
+            log(f"ERROR: token file not found at {token_file}")
+            raise SystemExit(1)
+        token = token_file.read_text().strip()
+
+    state = load_state(state_path)
+    failed_attempts = state.get("failed_attempts", {})
+
+    session = requests.Session()
+    idle_cycles = 0
+    cycle = 0
+
+    log("Starting targeted update watcher...")
+
+    while True:
+        cycle += 1
+        expected, clips_by_base, parsed_pages, unreadable_pages = load_cache_clips(cache_dir)
+        actual = count_local_mp3_by_base(out_dir)
+        hinted_bases = load_missing_hints(progress_missing_path)
+
+        missing = {base: (need - actual.get(base, 0)) for base, need in expected.items() if need > actual.get(base, 0)}
+        missing_titles = len(missing)
+        missing_files = sum(missing.values())
+
+        log(
+            f"Cycle {cycle}: cache_pages={parsed_pages} unreadable_pages={unreadable_pages} "
+            f"expected_files={sum(expected.values())} local_files={sum(actual.values())} "
+            f"missing_titles={missing_titles} missing_files={missing_files}"
+        )
+
+        cycle_max_downloads = resolve_cycle_download_limit(args.max_downloads, missing_files)
+
+        plan = build_plan(
+            missing_counts=missing,
+            clips_by_base=clips_by_base,
+            failed_attempts=failed_attempts,
+            hinted_bases=hinted_bases,
+            max_downloads=cycle_max_downloads,
+            per_clip_max_failures=max(args.max_retries, 1) if args.max_retries else 9999999,
+        )
+
+        downloaded_this_cycle = 0
+        if not plan:
+            log("No eligible clip downloads in this cycle.")
+        else:
+            log(f"Planned clip downloads this cycle: {len(plan)}")
+            for clip in plan:
+                clip_id = clip["id"]
+                if args.dry_run:
+                    log(f"DRY RUN: would download clip {clip_id} title={clip['title']!r}")
+                    continue
+                result = download_clip(
+                    session=session,
+                    clip=clip,
+                    out_dir=out_dir,
+                    token=token,
+                    timeout=args.timeout,
+                    max_retries=args.max_retries,
+                    max_backoff=args.max_backoff,
+                    jitter=args.jitter,
+                    base_sleep=args.download_sleep,
+                    log=log,
+                )
+                if result.get("ok"):
+                    failed_attempts.pop(clip_id, None)
+                    downloaded_this_cycle += 1
+                    log(f"Downloaded clip {clip_id} -> {result['path']}")
+                else:
+                    failed_attempts[clip_id] = int(failed_attempts.get(clip_id, 0)) + 1
+                    log(f"Failed clip {clip_id}: {result.get('error')}")
+                time.sleep(0.05)
+
+        save_state(state_path, failed_attempts)
+
+        if downloaded_this_cycle == 0:
+            idle_cycles += 1
+        else:
+            idle_cycles = 0
+
+        expected_after, _, _, _ = load_cache_clips(cache_dir)
+        actual_after = count_local_mp3_by_base(out_dir)
+        remaining_missing = sum(
+            need - actual_after.get(base, 0) for base, need in expected_after.items() if need > actual_after.get(base, 0)
+        )
+
+        if args.once:
+            if remaining_missing == 0:
+                log("Exiting after drain run (--once): no missing files remain.")
+                break
+            if not plan:
+                log("Exiting after drain run (--once): no eligible clips remain to satisfy missing files.")
+                break
+            log(f"Drain run (--once) continuing: remaining_missing_files={remaining_missing}")
+            continue
+
+        if args.stop_when_clean and remaining_missing == 0 and progress_fetch_complete(progress_summary_path):
+            log("No missing files and progress_check reports complete fetch. Exiting.")
+            break
+
+        if args.max_idle_cycles and idle_cycles >= args.max_idle_cycles:
+            log(f"Reached max idle cycles: {args.max_idle_cycles}. Exiting.")
+            break
+
+        time.sleep(args.poll_interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR upgrades the downloader/checker workflow to be reliable for ongoing library sync, and fixes feed pagination behavior so the newest songs are not skipped.

Key outcomes:

- `Suno_downloader.py` is now the intended first-pass download step (not legacy).
- Feed paging starts at `page=0` where applicable, so newest clips are included.
- Empty-title songs are supported with deterministic untitled filenames.
- Missing-file recovery is robust and drains all identified gaps by default.
- README is updated to match upstream style while documenting the new workflow clearly.

## Why

- Users reported that starting at page 1 skips the newest ~20 songs.  
  Confirmed: API page 0 and page 1 are distinct and non-overlapping.
- Empty-title clips must still download cleanly.
- Existing flow needed a more reliable step-by-step sync pattern for repeated runs.

## What Changed

### 1) `Suno_downloader.py` (first-pass workflow tool)

- Refactored into a reliable first-pass downloader.
- Defaults:
  - output directory: `out/`
  - token source: `token.txt` (via `--token-file`, override with `--token`)
- Added resilient retry/backoff controls for feed and download requests.
- Added safer file writes via temporary `.part` file + atomic rename.
- Empty-title naming:
  - `Untitled YYYY-MM-DD <id8>`
- Liked naming:
  - `(Liked) <title>` prefix when `is_liked=true`
- Supports planning / strict failure semantics:
  - `--dry-run`
  - `--fail-on-partial`
  - `--fail-on-download-errors`
- Fixed feed start index to `page=0`.

### 2) `progress_check.py` (status + cache sync)

- Added robust retries/backoff and partial fetch handling.
- Added smart cache head-sync behavior.
- Added detailed summary/report outputs in `out/`.
- Dedupes clips by clip ID before expected-count comparison.
- Updated pagination to start at `page=0`.
- Updated cache rewrite to zero-based page files (`page_0000.json`, ...).

### 3) `targeted_update.py` (missing-file recovery)

- `--once` now drains until missing files are cleared (or no eligible clips remain).
- `--max-downloads` default is now `0` (meaning unlimited per cycle).
- Removed stale downloaded-id blocking that could prevent valid re-downloads.
- Works with shared naming rules, including `(Liked)` and untitled fallback.

### 4) Docs and repo hygiene

- `README.md` rewritten to closely match upstream style/structure while documenting current workflow.
- Workflow now clearly states:
  1. `Suno_downloader.py` first pass
  2. `progress_check.py`
  3. `targeted_update.py`
  4. final `progress_check.py`
- Added/updated `notes.md`.
- Added `.gitignore` for local/runtime artifacts (`out/`, `token.txt`, etc.).

## Expected Workflow

```bash
python3 Suno_downloader.py --with-thumbnail
python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
python3 targeted_update.py --once --max-retries 8 --download-sleep 0.05
python3 progress_check.py --head-sync-pages 8 --max-retries 8 --sleep 0.05
```

Expected final status in `out/progress_summary.json`:

- `complete_api_fetch: true`
- `missing_titles: 0`
- `extra_titles: 0`

## Validation Performed

- Static compile checks:
  - `python3 -m py_compile Suno_downloader.py progress_check.py targeted_update.py`
- Runtime pagination checks:
  - Confirmed `progress_check.py` fetches `page 0` first.
  - Confirmed `Suno_downloader.py` fetches `Page 0` first.
- Targeted update drain behavior:
  - Verified `--once` exits only after missing set is cleared (or no eligible clips remain).
- End-to-end status verification:
  - Confirmed clean summary after sync (`missing_titles=0`, `extra_titles=0`).

## Notes

- This PR includes behavior changes intended to improve reliability in real-world repeated sync runs.
- Cache filenames are now zero-based when rewritten by `progress_check.py`.

Fixes #3
